### PR TITLE
Update way of including HAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
   "author": "Matteo Ferrando <matteo.ferrando2@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "hapi": "^17.2.0"
+    "@hapi/hapi": "^17.2.0"
   },
   "dependencies": {
-    "boom": "^7.1.1",
+    "@hapi/boom": "^7.1.1",
     "ip": "^1.1.5"
   },
   "peerDependencies": {
-    "hapi": ">= 17"
+    "@hapi/hapi": ">= 17"
   }
 }


### PR DESCRIPTION
We get errors when installing this depedency that we do not meet peer dependency requirements. The problem is `hapi-auth-ip-whitelist` requires `"hapi"`, but nowadays you have to include `"@hapi/hapi"` and (p)npm do not recognize these as the same dependency.